### PR TITLE
Changed the placement of some parts from RN mods

### DIFF
--- a/GameData/RP-0/Tree/TREE-Parts.cfg
+++ b/GameData/RP-0/Tree/TREE-Parts.cfg
@@ -6606,7 +6606,7 @@
 }
 @PART[MK2VApod]:FOR[xxxRP0]
 {
-    %TechRequired = matureCapsules
+    %TechRequired = improvedCapsules
     %cost = 8000
     %entryCost = 0
     RP0conf = true
@@ -7992,7 +7992,7 @@
 }
 @PART[RFTanks-Sep-AlLi]:FOR[xxxRP0]
 {
-    %TechRequired = 
+    %TechRequired = materialsScienceNF
     %cost = 0
     %entryCost = 40000
     RP0conf = true
@@ -26102,7 +26102,7 @@
 }
 @PART[luna_ktdu]:FOR[xxxRP0]
 {
-    %TechRequired = orbitalRocketry1966
+    %TechRequired = lunarRatedHeatshields
     %cost = 100
     %entryCost = 50000
     RP0conf = true
@@ -29808,7 +29808,7 @@
 }
 @PART[rn_r7_les_okt]:FOR[xxxRP0]
 {
-    %TechRequired = solids1964
+    %TechRequired = secondGenCapsules
     %cost = 5000
     %entryCost = 175000
     RP0conf = true
@@ -30742,7 +30742,7 @@
 }
 @PART[rn_tks_rcs_block]:FOR[xxxRP0]
 {
-    %TechRequired = spaceStationControl
+    %TechRequired = improvedCapsules
     %cost = 400
     %entryCost = 4000
     RP0conf = true
@@ -30750,7 +30750,7 @@
 }
 @PART[rn_tks_retro]:FOR[xxxRP0]
 {
-    %TechRequired = solids1976
+    %TechRequired = improvedCapsules
     %cost = 750
     %entryCost = 8400
     RP0conf = true
@@ -30762,7 +30762,7 @@
 }
 @PART[rn_tks_va_rcs]:FOR[xxxRP0]
 {
-    %TechRequired = spaceStationControl
+    %TechRequired = improvedCapsules
     %cost = 1400
     %entryCost = 16000
     RP0conf = true
@@ -30870,7 +30870,7 @@
 }
 @PART[rn_va_capsule]:FOR[xxxRP0]
 {
-    %TechRequired = matureCapsules
+    %TechRequired = improvedCapsules
     %cost = 8000
     %entryCost = 0
     RP0conf = true
@@ -30894,7 +30894,7 @@
 }
 @PART[rn_va_les]:FOR[xxxRP0]
 {
-    %TechRequired = matureCapsules
+    %TechRequired = improvedCapsules
     %cost = 1200
     %entryCost = 4800
     RP0conf = true
@@ -30906,7 +30906,7 @@
 }
 @PART[rn_va_para]:FOR[xxxRP0]
 {
-    %TechRequired = advancedUncrewedLanding
+    %TechRequired = improvedCapsules
     %cost = 0
     %entryCost = 1
     RP0conf = true
@@ -30940,7 +30940,7 @@
 }
 @PART[rn_voskhod_para]:FOR[xxxRP0]
 {
-    %TechRequired = earlyLanding
+    %TechRequired = secondGenCapsules
     %cost = 0
     %entryCost = 1
     RP0conf = true
@@ -30948,7 +30948,7 @@
 }
 @PART[rn_voskhod_retro]:FOR[xxxRP0]
 {
-    %TechRequired = solids1964
+    %TechRequired = secondGenCapsules
     %cost = 800
     %entryCost = 25000
     RP0conf = true
@@ -31210,7 +31210,7 @@
 }
 @PART[rn_zond_les]:FOR[xxxRP0]
 {
-    %TechRequired = solids1966
+    %TechRequired = lunarOrbiterCapsules
     %cost = 5000
     %entryCost = 175000
     RP0conf = true
@@ -33819,4 +33819,40 @@
     %entryCost = 1
     RP0conf = true
     @description ^=:$: <b><color=green>From Chaka Monkey mod</color></b>
+}
+@PART[rn_lok_sa_rcs]:FOR[xxxRP0]
+{
+    %TechRequired = matureCapsules
+    %cost = 50
+    %entryCost = 500
+    RP0conf = false
+    @description ^=:$: <b><color=green>From RN Soyuz mod</color></b>
+
+    MODULE
+    { name = ModuleTagReentry }
+
+}
+@PART[ok-sa-rcs]:FOR[xxxRP0]
+{
+    %TechRequired = secondGenCapsules
+    %cost = 50
+    %entryCost = 500
+    RP0conf = false
+    @description ^=:$: <b><color=green>From RN Soyuz mod</color></b>
+
+    MODULE
+    { name = ModuleTagReentry }
+
+}
+@PART[KK_ATK_GEM60]:FOR[xxxRP0]
+{
+    %TechRequired = solids1998
+    %cost = 1800
+    %entryCost = 36000
+    RP0conf = true
+    @description ^=:$: <b><color=green>From ATK Propulsion Pack mod</color></b>
+
+    MODULE
+    { name = ModuleTagEngineSolid }
+
 }


### PR DESCRIPTION
Moved to Second Gen Capsules: Soyuz 7K-OK & 7K-T LES, Soyuz/Zond RCS Block, Voskhod Retro Package, Voskhod Main Chute

Moved to Lunar Rated Heatshields: Luna 9/10/13 KTDU (aka breaking stage for Luna landers)

Moved to Lunar Orbiter Capsules: Proton Zond 7K-L1 LES.

Move to Mature Capsules: LOK Descent Module RCS Block

Moved to Improved Capsules: TKS RCS Block, VA Retro Block, VA RCS Propulsion Block, VA Capsule, VA Launch Escape System, VA Capsule Main Parachute, TKS VA Command Module (last one is from Ven's)

Moved to 1998-2008 Solid Rocket Engines: GEM 60 (from ATK Propulsion)